### PR TITLE
Update timesheet link as of 14 Jan 2020

### DIFF
--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -2,7 +2,7 @@
 
 class StaticPagesController < ApplicationController
   GUIDE_URL = 'https://docs.google.com/document/d/1rNjei4GOOAiDBk4p9EP4ipvmTcq2jJxaY-bIR8XUCVw/edit?usp=sharing'
-  CLAIM_FORM_URL = 'https://drive.google.com/file/d/10eW5eZ_SesicOX_mz5GHmlDjuhafZFDk/view?usp=drivesdk'
+  CLAIM_FORM_URL = 'http://tinyurl.com/committs'
 
   def guide
     redirect_to GUIDE_URL

--- a/app/views/static_pages/claim_form.html.erb
+++ b/app/views/static_pages/claim_form.html.erb
@@ -1,1 +1,1 @@
-<a href="https://drive.google.com/file/d/10eW5eZ_SesicOX_mz5GHmlDjuhafZFDk/view?usp=drivesdk" target="_blank">Open the claim form on a new tab</a>
+<a href="http://tinyurl.com/committs" target="_blank">Open the claim form on a new tab</a>


### PR DESCRIPTION
Actually don't need to update `claim_form.html.erb`, as the redirection is done directly in the controller. But I am updating it so the future maintainers may not be as confused